### PR TITLE
Fixed bug with duplicate dictionary keys

### DIFF
--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -90,8 +90,9 @@ def parse(fp, mapper=dict):
 
             # we have a key with value in parenthesis, so we make a new dict obj (level deeper)
             if val is None:
-                stack[-1][key] = mapper()
-                stack.append(stack[-1][key])
+                _m = mapper()
+                stack[-1][key] = _m
+                stack.append(_m)
                 expect_bracket = True
 
             # we've matched a simple keyvalue pair, map it to the last dict obj in the stack
@@ -249,8 +250,9 @@ def binary_loads(s, mapper=dict):
         key, idx = read_string(s, idx)
 
         if t == BIN_NONE:
-            stack[-1][key] = mapper()
-            stack.append(stack[-1][key])
+            _m = mapper()
+            stack[-1][key] = _m
+            stack.append(_m)
         elif t == BIN_STRING:
             stack[-1][key], idx = read_string(s, idx)
         elif t == BIN_WIDESTRING:


### PR DESCRIPTION
With a dictionary implementation which allows duplicate keys like [this one](https://raw.githubusercontent.com/rossengeorgiev/dota2_notebooks/master/DuplicateOrderedDict_for_VDF.ipynb) data in the form of:
```
{
  7: {1:2},
  7: {2:3},
}
```
could result in something like:
```
{
  7: {
    1:2,
    2:3
  }
}
```

Testdata [here](https://github.com/SleepProgger/Binary-vdf-test-data/blob/master/products/p_34719.bvdf)

This specific behavior is bound to that specific DuplicateDict implementation, but almost all implementations would have similar problems.

<hr>
Generally IMHO the default `mapper` should be some DuplicateDict impl.
I mean if duplicate keys are allowed in this protocol shouldn't the default setting of this lib be to support this ?