### PR TITLE
Fix collection deprecation warning

### DIFF
--- a/vdf/vdict.py
+++ b/vdf/vdict.py
@@ -5,7 +5,7 @@ if sys.version_info[0] >= 3:
     _iter_values = 'values'
     _range = range
     _string_type = str
-    import collections as _c
+    import collections.abc as _c
     class _kView(_c.KeysView):
         def __iter__(self):
             return self._mapping.iterkeys()


### PR DESCRIPTION
In python 3.3 the Collections Abstract Base Classes were moved to the collections.abc but for backwards compatibility were still available from collections. This compatibility will be removed after in python 3.8.

Signed-off-by: Nicholas Malcolm <bubylou7@gmail.com>