### PR TITLE
Added support for more unquoted characters and inline empty blocks

### DIFF
--- a/tests/test_vdf.py
+++ b/tests/test_vdf.py
@@ -330,6 +330,16 @@ class testcase_VDF(unittest.TestCase):
         self.assertEqual(vdf.loads(INPUT), EXPECTED)
         self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
 
+    def test_space_for_unquoted(self):
+        INPUT = 'a b c d   \n efg h i\t // j k\n'
+        EXPECTED= {
+            'a': 'b c d',
+            'efg': 'h i',
+        }
+
+        self.assertEqual(vdf.loads(INPUT), EXPECTED)
+        self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
+
     def test_merge_multiple_keys_on(self):
         INPUT = '''
         a
@@ -437,9 +447,9 @@ class testcase_VDF(unittest.TestCase):
             "key3" value3
         }
         root2 { }
-        root3 {  
+        root3 {
             "key1" "value1"
-            key2 {   
+            key2 {
 
             }
             "key3" value3

--- a/tests/test_vdf.py
+++ b/tests/test_vdf.py
@@ -428,6 +428,41 @@ class testcase_VDF(unittest.TestCase):
         self.assertEqual(vdf.loads(INPUT), EXPECTED)
         self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
 
+    def test_inline_opening_bracker(self):
+        INPUT = '''
+        "root1" {
+            "key1" {
+            }
+            key2 "value2"
+            "key3" value3
+        }
+        root2 { }
+        root3 {  
+            "key1" "value1"
+            key2 {   
+
+            }
+            "key3" value3
+        }
+        '''
+
+        EXPECTED = {
+            'root1': {
+                'key1': {},
+                'key2': 'value2',
+                'key3': 'value3',
+            },
+            'root2': {},
+            'root3': {
+                'key1': 'value1',
+                'key2': {},
+                'key3': 'value3',
+            }
+        }
+
+        self.assertEqual(vdf.loads(INPUT), EXPECTED)
+        self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
+
 class testcase_VDF_other(unittest.TestCase):
     def test_dumps_pretty_output(self):
         tests = [

--- a/tests/test_vdf.py
+++ b/tests/test_vdf.py
@@ -319,11 +319,12 @@ class testcase_VDF(unittest.TestCase):
         self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
 
     def test_wierd_symbols_for_unquoted(self):
-        INPUT = 'a asd.vdf\nb language_*lol*\nc zxc_-*.sss//'
+        INPUT = 'a asd.vdf\nb language_*lol*\nc zxc_-*.sss//\nd<2?$% /cde/$fgh/<i>'
         EXPECTED = {
             'a': 'asd.vdf',
             'b': 'language_*lol*',
             'c': 'zxc_-*.sss',
+            'd<2?$%': '/cde/$fgh/<i>',
             }
 
         self.assertEqual(vdf.loads(INPUT), EXPECTED)
@@ -393,6 +394,39 @@ class testcase_VDF(unittest.TestCase):
 
         self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
 
+    def test_single_line_empty_block(self):
+        INPUT = '''
+        "root1"
+        {
+            "key1" {}
+            key2 "value2"
+            "key3" value3
+        }
+        root2 { }
+        root3
+        {
+            "key1" "value1"
+            key2 {   }
+            "key3" value3
+        }
+        '''
+
+        EXPECTED = {
+            'root1': {
+                'key1': {},
+                'key2': 'value2',
+                'key3': 'value3',
+            },
+            'root2': {},
+            'root3': {
+                'key1': 'value1',
+                'key2': {},
+                'key3': 'value3',
+            }
+        }
+
+        self.assertEqual(vdf.loads(INPUT), EXPECTED)
+        self.assertEqual(vdf.loads(INPUT, escaped=False), EXPECTED)
 
 class testcase_VDF_other(unittest.TestCase):
     def test_dumps_pretty_output(self):

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -89,7 +89,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
-                             r'|(?P<val>[a-z0-9\-\_\\\?\*\.]+)'
+                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.])+)'
                              r'))?',
                              flags=re.I)
 

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -135,14 +135,13 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
                                       (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 0, line))
 
             key = match.group('key') if match.group('qkey') is None else match.group('qkey')
-            if match.group('qval') is None:
+            val = match.group('qval')
+            if val is None:
                 val = match.group('val')
                 if val is not None:
                     val = val.rstrip()
                     if val == "":
                         val = None
-            else:
-                val = match.group('qval')
 
             if escaped:
                 key = _unescape(key)

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -86,7 +86,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     stack = [mapper()]
     expect_bracket = False
 
-    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?\$?[a-z0-9\-\_\\\?]+))'
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
                              r'|(?P<val>[a-z0-9\-\_\\\?\*\.]+)'

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -86,7 +86,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     stack = [mapper()]
     expect_bracket = False
 
-    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%<>]+))'
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])*)"|(?P<key>#?[a-z0-9\-\_\\\?$%<>]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
                              r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<> ])+)'

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -89,7 +89,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%<>]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
-                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<>])+)'
+                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<> ])+)'
                              r'|(?P<sblock>{[ \t]*)(?P<eblock>})?'
                              r'))?',
                              flags=re.I)
@@ -135,7 +135,14 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
                                       (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 0, line))
 
             key = match.group('key') if match.group('qkey') is None else match.group('qkey')
-            val = match.group('val') if match.group('qval') is None else match.group('qval')
+            if match.group('qval') is None:
+                val = match.group('val')
+                if val is not None:
+                    val = val.rstrip()
+                    if val == "":
+                        val = None
+            else:
+                val = match.group('qval')
 
             if escaped:
                 key = _unescape(key)

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -90,7 +90,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
                              r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<>])+)'
-                             r'|(?P<eblock>{[ \t]*})'
+                             r'|(?P<sblock>{[ \t]*)(?P<eblock>})?'
                              r'))?',
                              flags=re.I)
 
@@ -149,9 +149,10 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
                     stack[-1][key] = _m
 
                 if match.group('eblock') is None:
-                    # only expect a bracket if the block is not closed on the same line
+                    # only expect a bracket if it's not already closed or on the same line
                     stack.append(_m)
-                    expect_bracket = True
+                    if match.group('sblock') is None:
+                        expect_bracket = True
 
             # we've matched a simple keyvalue pair, map it to the last dict obj in the stack
             else:

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -86,7 +86,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     stack = [mapper()]
     expect_bracket = False
 
-    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?]+))'
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?\$?[a-z0-9\-\_\\\?]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
                              r'|(?P<val>[a-z0-9\-\_\\\?\*\.]+)'

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -86,10 +86,10 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     stack = [mapper()]
     expect_bracket = False
 
-    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%]+))'
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%<>]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
-                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$])+)'
+                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<>])+)'
                              r'|(?P<eblock>{[ \t]*})'
                              r'))?',
                              flags=re.I)

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -89,7 +89,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
-                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.])+)'
+                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$])+)'
                              r'))?',
                              flags=re.I)
 

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -90,6 +90,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
                              r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$])+)'
+                             r'|(?P<eblock>{[ \t]*})'
                              r'))?',
                              flags=re.I)
 
@@ -147,8 +148,10 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
                     _m = mapper()
                     stack[-1][key] = _m
 
-                stack.append(_m)
-                expect_bracket = True
+                if match.group('eblock') is None:
+                    # only expect a bracket if the block is not closed on the same line
+                    stack.append(_m)
+                    expect_bracket = True
 
             # we've matched a simple keyvalue pair, map it to the last dict obj in the stack
             else:

--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -86,7 +86,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     stack = [mapper()]
     expect_bracket = False
 
-    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$]+))'
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])+)"|(?P<key>#?[a-z0-9\-\_\\\?$%]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
                              r'|(?P<val>[a-z0-9\-\_\\\?\*\.]+)'


### PR DESCRIPTION
CSGO has material (.vmt) files that have unquoted keys starting with $.

For example, csgo/materials/grass/hr_grass/grass_a.vmt:

```
LightmappedGeneric
{
$baseTexture "grass/hr_grass/grass_a"
$bumpmap "grass/hr_grass/grass_a_normals"

}
```

This fixes the parsing of these files.