### PR TITLE
Fix dota2-items parse error: <TypeError: 'str' object does not support item assignment>

### DIFF
--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -134,7 +134,7 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
 
             # we have a key with value in parenthesis, so we make a new dict obj (level deeper)
             if val is None:
-                if merge_duplicate_keys and key in stack[-1]:
+                if merge_duplicate_keys and key in stack[-1] and not isinstance(stack[-1][key], mapper):
                     _m = stack[-1][key]
                 else:
                     _m = mapper()


### PR DESCRIPTION
I have an error when i parse **items_game.txt** from this link: [GameTracking-Dota2](https://raw.githubusercontent.com/SteamDatabase/GameTracking-Dota2/master/game/dota/pak01_dir/scripts/items/items_game.txt)

Traceback:
```
Traceback (most recent call last):
  File "C:\Users\***\AppData\Local\Programs\Python\Python38\lib\asyncio\runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "C:\Users\***\AppData\Local\Programs\Python\Python38\lib\asyncio\base_events.py", line 612, in run_until_complete
    return future.result()
  File "C:/Users/***/***/***/Python/NamePicker/main.py", line 71, in main
    await fetcher.fetch_all_sources()
  File "C:/Users/***/***/***/Python/NamePicker/main.py", line 37, in fetch_all_sources
    tasks_response = await asyncio.gather(*fetch_tasks)
  File "C:/Users/***/***/***/Python/NamePicker/main.py", line 61, in fetch_result
    result = vdf.load(fp, mapper=vdf.VDFDict)
  File "C:\Users\***\***\***\Python\NamePicker\venv\lib\site-packages\vdf\__init__.py", line 191, in load
    return parse(fp, **kwargs)
  File "C:\Users\***\***\***\Python\NamePicker\venv\lib\site-packages\vdf\__init__.py", line 158, in parse
    stack[-1][key] = _unescape(val) if escaped else val
TypeError: 'str' object does not support item assignment
```

I've searched for the problem and found out that the error occurs on the 557707 line in this file. I think that error occurs because the value has become a `dict` (before that it is clear that value is a `str`)

Maybe the solution is not perfect, but for me - it completely solves the problem with parsing