### PR TITLE
tests: Try to use unittest.mock from the Python standard library

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-mock
+mock; python_version < '3.3'
 
 coverage>=5.0; python_version == '2.7' or python_version >= '3.5'
 pytest-cov>=2.7.0; python_version == '2.7' or python_version >= '3.5'

--- a/tests/test_vdf.py
+++ b/tests/test_vdf.py
@@ -1,6 +1,10 @@
 import unittest
-import mock
 import sys
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 try:
         from StringIO import StringIO


### PR DESCRIPTION
Only fall back to the standalone mock module if the Python version is
too old to have it in the standard library.