### PR TITLE
tests: Avoid problematic use of "is" operator

### DIFF
--- a/tests/test_vdf.py
+++ b/tests/test_vdf.py
@@ -124,7 +124,7 @@ class testcase_routine_parse(unittest.TestCase):
         result = vdf.loads(vdf.BOMS + '"asd" "123"')
         self.assertEqual(result, {'asd': '123'})
 
-        if sys.version_info[0] is 2:
+        if sys.version_info[0] == 2:
             result = vdf.loads(vdf.BOMS_UNICODE + '"asd" "123"')
             self.assertEqual(result, {'asd': '123'})
 


### PR DESCRIPTION
The "is" operator compares objects by identity, not value. It would be
valid for a Python implementation to have two different int objects
with value 2 (although in practice CPython doesn't).

Recent Python versions detect this with a warning:

    SyntaxWarning: "is" with a literal. Did you mean "=="?