### PR TITLE
vdf2json: fix stdin/stdout for large inputs (TypeError: can't concat str to bytes)

### DIFF
--- a/vdf2json/vdf2json/cli.py
+++ b/vdf2json/vdf2json/cli.py
@@ -5,6 +5,7 @@ import sys
 import json
 import vdf
 import codecs
+import io
 from collections import OrderedDict
 
 
@@ -28,13 +29,13 @@ def main():
         args.infile.close()
         args.infile = codecs.open(args.infile.name, 'r', encoding=args.ei)
     else:
-        args.infile = codecs.getreader(args.ei)(sys.stdin)
+        args.infile = io.TextIOWrapper(sys.stdin.buffer, args.ei)
 
     if args.outfile is not sys.stdout:
         args.outfile.close()
         args.outfile = codecs.open(args.outfile.name, 'w', encoding=args.eo)
     else:
-        args.outfile = codecs.getwriter(args.eo)(sys.stdout)
+        args.outfile = io.TextIOWrapper(sys.stdout.buffer, args.eo)
 
     data = vdf.loads(args.infile.read(), mapper=OrderedDict)
 


### PR DESCRIPTION
not sure if this works for all python versions, but I had to do this to avoid a TypeError: can't concat str to bytes

```sh
$ cat csgo_english.txt.gz | gunzip | vdf2json > /dev/null
Traceback (most recent call last):
  File "/home/mark/.local/bin/vdf2json", line 8, in <module>
    sys.exit(main())
  File "/home/mark/.local/lib/python3.8/site-packages/vdf2json/cli.py", line 39, in main
    data = vdf.loads(args.infile.read(), mapper=OrderedDict)
  File "/usr/lib/python3.8/codecs.py", line 500, in read
    data = self.bytebuffer + newdata
TypeError: can't concat str to bytes
```

after the fix this works

```sh
$ cat csgo_english.txt.gz | gunzip | python3 vdf2json/vdf2json/cli.py > /dev/null
// all ok, no error
```