### PR TITLE
allow '+' in keys and '|' in values

### DIFF
--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -86,10 +86,10 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
     stack = [mapper()]
     expect_bracket = False
 
-    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])*)"|(?P<key>#?[a-z0-9\-\_\\\?$%<>]+))'
+    re_keyvalue = re.compile(r'^("(?P<qkey>(?:\\.|[^\\"])*)"|(?P<key>#?[a-z0-9\-\_\\\?\+$%<>]+))'
                              r'([ \t]*('
                              r'"(?P<qval>(?:\\.|[^\\"])*)(?P<vq_end>")?'
-                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.$<> ])+)'
+                             r'|(?P<val>(?:(?<!/)/(?!/)|[a-z0-9\-\_\\\?\*\.\|$<> ])+)'
                              r'|(?P<sblock>{[ \t]*)(?P<eblock>})?'
                              r'))?',
                              flags=re.I)


### PR DESCRIPTION
This minimally fixes parsing of most gameinfo.txt and closes #49 without implementing functionality that doesn't seem to be part of the specification of KeyValues, which is the separation of keys and repetition of values by using the + operator.

Example files: 
[gameinfo.txt](https://github.com/ValvePython/vdf/files/11011626/gameinfo.txt)
[gameinfo.txt](https://github.com/ValvePython/vdf/files/11011629/gameinfo.txt)
[gameinfo.txt](https://github.com/ValvePython/vdf/files/11011636/gameinfo.txt)
[gameinfo.txt](https://github.com/ValvePython/vdf/files/11011644/gameinfo.txt)