### PR TITLE
CI: Update list of Python versions to test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,9 +26,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
         no-coverage: [0]
         include:
+          - os: ubuntu-20.04
+            python-version: '3.5'
+          - os: ubuntu-20.04
+            python-version: '3.6'
           - os: ubuntu-latest
             python-version: pypy-2.7
             no-coverage: 1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
         no-coverage: [0]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
* CI: Run tests on Python 3.11 and 3.12

* CI: Clean up EOL Python versions
    
    Github no longer offers Python 2.x at all, so stop running CI on that.
    
    Github no longer offers Python 3.5 or 3.6 on its latest Ubuntu images,
    so use an older Ubuntu image to run those.