### PR TITLE
Add deserialization support for new binary VDF w/ key table

### DIFF
--- a/tests/test_binary_vdf.py
+++ b/tests/test_binary_vdf.py
@@ -166,6 +166,12 @@ class BinaryVDF(unittest.TestCase):
             vdf.binary_load(buf, raise_on_remaining=True)
         self.assertEqual(buf.read(), b'aaaa')
 
+    def test_key_table(self):
+        test = b'\x01\x00\x00\x00\x00value\x00\x01\x02\x00\x00\x00value3\x00\x08'
+        key_table = ['key', 'key2', 'key3', 'key4']
+
+        self.assertEqual({'key': 'value', 'key3': 'value3'}, vdf.binary_loads(test, key_table=key_table))
+
     def test_vbkv_loads_empty(self):
         with self.assertRaises(ValueError):
             vdf.vbkv_loads(b'')


### PR DESCRIPTION
The new Steam beta introduced a new `appinfo.vdf` version. This appinfo.vdf V29 introduces a new binary VDF format which does not include field keys in binary VDF segments as-is. Instead, each key is represented by a 32-bit integer which needs to be mapped to an actual string using a table stored at the end of the `appinfo.vdf` file.

This also means the binary VDF segments in this case are no longer self-contained. The developer can parse and provide the table themselves or instead use the `ValvePython/steam` library which contains a function to parse `appinfo.vdf` files.

Also see SteamDatabase/SteamAppInfo@56b1fec7f5ce6be961c3e44cf9baf117e363ad91

Refs ValvePython/steam#462